### PR TITLE
Group suggestions by line, and fix a typo with XPath filter

### DIFF
--- a/lookout/style/typos_checker/analyzer.py
+++ b/lookout/style/typos_checker/analyzer.py
@@ -34,20 +34,20 @@ class CommentsCheckingAnalyzer(Analyzer):
                 for index, comment_node in enumerate(comment_nodes):
                     if index in suggestions.keys():
                         corrections = suggestions[index]
+                        line_suggestions = ""
                         for token in corrections.keys():
-                            comment = Comment()
-                            comment.file = change.head.path
                             corrections_line = ""
                             for candidate in corrections[token]:
-                                corrections_line += candidate[0] + " (%d)," % \
-                                                    int(candidate[1] * 100)
-                            comment.text = "Typo inside comment in token '%s'. " \
-                                           "Possible corrections:" % token +\
-                                           corrections_line[:-1]
-                            comment.line = comment_node.start_position.line
-                            comment.confidence = int(
-                                corrections[token][0][1] * 100)
-                            comments.append(comment)
+                                corrections_line += " `%s` (%d)," % \
+                                                    (candidate[0], int(candidate[1] * 100) )
+                            line_suggestions += "Typo inside comment in word `%s`. " \
+                                           "Possible corrections: %s\n" % \
+                                           ( token, corrections_line[:-1] )
+                        comment = Comment()
+                        comment.file = change.head.path
+                        comment.line = comment_node.start_position.line
+                        comment.text = line_suggestions
+                        comments.append(comment)
         return comments
 
     @classmethod

--- a/lookout/style/typos_checker/analyzer.py
+++ b/lookout/style/typos_checker/analyzer.py
@@ -20,12 +20,13 @@ class CommentsCheckingAnalyzer(Analyzer):
     @with_changed_uasts_and_contents
     def analyze(self, ptr_from: ReferencePointer, ptr_to: ReferencePointer,
                 data_request_stub: DataStub, **data) -> [Comment]:
+        commentFilter = "//*[@roleComment]"
         changes = data["changes"]
         comments = []
 
         for change in changes:
-            old_comments = set([node.token for node in bblfsh.filter(change.base.uast, "//*[@roleIComment]")])
-            comment_nodes = [node for node in bblfsh.filter(change.head.uast, "//*[@roleComment]")
+            old_comments = set([node.token for node in bblfsh.filter(change.base.uast, commentFilter)])
+            comment_nodes = [node for node in bblfsh.filter(change.head.uast, commentFilter)
                              if node.token not in old_comments]
             comment_tokens = [node.token for node in comment_nodes]
             if len(comment_tokens) > 0:


### PR DESCRIPTION
**One fix:**
05993d2 Fix typo with the XPath filter used for comments in base revision

**One enhancement:**
5cf9634 Group suggestions made for the same comment as suggested during the hackathon demo

example of grouped suggestions:
![image](https://user-images.githubusercontent.com/2437584/45692839-0b8d6000-bb5c-11e8-91c9-35b58ed9ff07.png)
